### PR TITLE
Fixes for Windows operating system

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,7 @@ export default {
 
     provideLinter: () => {
         const helpers = require("atom-linter");
-        const regex = "(?<file>.+):(?<line>\\d+):(?<col>\\d+):((.|\\n)*)(?<type>(Error|Warning|Note)):\\s*(?<message>.*)";
+        const regex = "(?<file>.+):(?<line>\\d+)[\.:](?<col>\\d+):((.|\\r|\\n)*)(?<type>(Error|Warning|Note)):\\s*(?<message>.*)";
         const tmpdir = require('tmp').dirSync().name;
         return {
             name: "gfortran",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "atom-package-deps": "^4.0.1",
     "tmp": "^0.0.28"
   },
-  "packages-deps": [
+  "package-deps": [
     "linter"
   ],
   "eslintConfig": {


### PR DESCRIPTION
Hi,
I have made some changes so your package runs correctly on Windows (Mingw). This just required some changes to the regex. 

 * Firstly, adding `\r` to as a possible new line character (newline is `\r\n` on windows). 
 * Also, errors on Windows appear as the form <line>.<col> rather than <line>:<col> so I have put the list match `[\.:]` in the regex.

I have tested on my Windows and Ubuntu system and everything seems to work properly.

PS. I also found that in the Atom developer tools console that it was complaining about not finding package-deps. I therefore made the change as seen in the diff of package.json, which got rid of the error. However, I am new to Atom so the maybe incorrect.

Cheers.
