### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,11 +12,11 @@ export default {
         },
     },
 
-    activate: () => {
+    activate() {
         require("atom-package-deps").install("linter-gfortran");
     },
 
-    provideLinter: () => {
+    provideLinter() {
         const helpers = require("atom-linter");
         const path = require('path');
         const regex = "(?<file>[^\n:]+):(?<line>\\d+)([\.:](?<col>\\d+))?:((.|\\r|\\n)*?)(?<type>(Error|Warning|Note)):\\s*(?<message>.*)";


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.